### PR TITLE
PR for issue #2

### DIFF
--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -66,7 +66,8 @@ class QuerySetAsync(QuerySet):
 
     def __aiter__(self):
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            executor.submit(self._fetch_all)
+            f = executor.submit(self._fetch_all)
+            f.result()
 
         return AsyncIter(self._result_cache)
 


### PR DESCRIPTION
```
async def get_data():
    return await Building.objects.async_all()

@app.get("/buildings", response_model=List[BuildingSummary])
async def get_buildings(
    limit: conint(le=500),
    skip: conint(le=500),
    x_pm_org: Optional[List[int]] = Header(None, alias="x-pm-org"),
    x_pm_org_id: Optional[List[int]] = Header(None, alias="x-pm-org-id"),
    x_pm_user_type: Optional[str] = Header(None, alias="x-pm-user-type"),
) -> List[BuildingSummary]:
    """
    Building List
    [{'ApiKeyAuth': []}, {'PmOrg': []}]
    """

    org.set(x_pm_org)
    pydant, item_all = paths["get_buildings"]



    # this works
    data = await get_data()

    # this also works
    data2 = await Buildings.objects.async_all()



    result = []
    async for item in data[skip:limit]:
        print(item.__dict__)
        result.append(pydant.from_orm(item).dict())
    return result
```

Related to: #2 

I just tested it locally and it appears to work.

Thanks for the quick response.

Not sure where to ask this, possibly could enable the "discussions" section on the repo? 

But how does the `ThreadPoolExecutor` work with something like psycogreen/eventlet?
