### PR TITLE
add none query feature and test for the same

### DIFF
--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -42,6 +42,9 @@ class QuerySetAsync(QuerySet):
     async def async_first(self):
         return await sync_to_async(self.first, thread_sensitive=True)()
 
+    async def async_none(self):
+        return await sync_to_async(self.none, thread_sensitive=True)()
+
     async def async_last(self):
         return await sync_to_async(self.last, thread_sensitive=True)()
 

--- a/tests/test_django_async_orm.py
+++ b/tests/test_django_async_orm.py
@@ -5,6 +5,7 @@ from django.test import TestCase, tag, TransactionTestCase
 from django.conf import settings
 from django.apps import apps
 from unittest import IsolatedAsyncioTestCase
+from django.db.models.query import EmptyQuerySet
 import time
 
 from .models import TestModel
@@ -134,6 +135,11 @@ class ModelTestCase(TransactionTestCase, IsolatedAsyncioTestCase):
     async def test_async_count(self):
         result = await TestModel.objects.async_all()
         self.assertEqual(result.count(), 1)
+
+    @tag('ci')
+    async def test_async_none(self):
+        result = await TestModel.objects.none()
+        self.assertEqual(result, EmptyQuerySet)
 
     @tag('ci')
     async def test_async_aiter(self):

--- a/tests/test_django_async_orm.py
+++ b/tests/test_django_async_orm.py
@@ -5,7 +5,6 @@ from django.test import TestCase, tag, TransactionTestCase
 from django.conf import settings
 from django.apps import apps
 from unittest import IsolatedAsyncioTestCase
-from django.db.models.query import EmptyQuerySet
 import time
 
 from .models import TestModel
@@ -138,8 +137,8 @@ class ModelTestCase(TransactionTestCase, IsolatedAsyncioTestCase):
 
     @tag('ci')
     async def test_async_none(self):
-        result = await TestModel.objects.none()
-        self.assertEqual(result, EmptyQuerySet)
+        result = await TestModel.objects.async_none()
+        self.assertEqual(list(result), [])
 
     @tag('ci')
     async def test_async_aiter(self):


### PR DESCRIPTION
Added none query feature:

in Django ORM, calling none() will create a queryset that never returns any objects and no query will be executed when accessing the results. A qs.none() queryset is an instance of EmptyQuerySet.

example:
>>> Entry.objects.none()
<QuerySet []>
>>> from django.db.models.query import EmptyQuerySet
>>> isinstance(Entry.objects.none(), EmptyQuerySet)
True