### PR TITLE
Comply with Django async syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v2
 
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 ## Disclaimer: Don't use this module in production it's still in active development.
 
 # Django Async Orm
+
 Django module that brings async to django ORM.
 
 # Installing
+
 ```
 python -m pip install django-async-orm
-``` 
+```
 
 then add `django_async_orm` to your `INSTALLED_APPS` list:
 
@@ -18,6 +20,7 @@ INSTALLED_APPS = [
     'django_async_orm'
 ]
 ```
+
 # Usage
 
 Django Async Orm will patch all your existing models to add `async_*` prefixed methods.
@@ -50,8 +53,8 @@ async def all_models():
 
 Some wrappers are also available for template rendering, form validation and login/logout
 
-
 #### Async login
+
 ```python
 from django_async_orm.wrappers import alogin
 
@@ -61,6 +64,7 @@ async def my_async_view(request):
 ```
 
 #### Form validation
+
 ```python
 
 from django_async_orm.wrappers import aform_is_valid
@@ -69,9 +73,8 @@ async def a_view(request):
     is_valid_form = await aform_is_valid(form)
     if is_valid_form:
         ...
-    
-```
 
+```
 
 # Django ORM support:
 
@@ -79,86 +82,84 @@ This is an on going projects, not all model methods are ported.
 
 ### Manager:
 
-| methods                                  | supported  | comments |
-|------------------------------------------|------------|----------|
-| `Model.objects.aget`                | ✅ |  |
-| `Model.objects.acreate`             | ✅ |  |
-| `Model.objects.acount`              | ✅ |  |
-| `Model.objects.anone`               | ✅ |  |
-| `Model.objects.abulk_create`        | ✅ |  |
-| `Model.objects.abulk_update`        | ✅ |  |
-| `Model.objects.aget_or_create`      | ✅ |  |
-| `Model.objects.aupdate_or_create`   | ✅ |  |
-| `Model.objects.aearliest`           | ✅ |  |
-| `Model.objects.alatest`             | ✅ |  |
-| `Model.objects.afirst`              | ✅ |  |
-| `Model.objects.alast`               | ✅ |  |
-| `Model.objects.ain_bulk`            | ✅ |  |
-| `Model.objects.adelete`             | ✅ |  |
-| `Model.objects.aupdate`             | ✅ |  |
-| `Model.objects.aexists`             | ✅ |  |
-| `Model.objects.aexplain`            | ✅ |  |
-| `Model.objects.araw`                | ✅ |  |
-| `Model.objects.aall`                | ✅ |  |
-| `Model.objects.afilter`             | ✅ |  |
-| `Model.objects.aexclude`            | ✅ |  |
-| `Model.objects.acomplex_filter`     | ✅ |  |
-| `Model.objects.aunion`              | ✅ |  |
-| `Model.objects.aintersection`       | ✅ |  |
-| `Model.objects.adifference`         | ✅ |  |
-| `Model.objects.aselect_for_update`  | ✅ |  |
-| `Model.objects.aprefetch_related`   | ✅ |  |
-| `Model.objects.aannotate`           | ✅ |  |
-| `Model.objects.aorder_by`           | ✅ |  |
-| `Model.objects.adistinct`           | ✅ |  |
-| `Model.objects.adifference`         | ✅ |  |
-| `Model.objects.aextra`              | ✅ |  |
-| `Model.objects.areverse`            | ✅ |  |
-| `Model.objects.adefer`              | ✅ |  |
-| `Model.objects.aonly`               | ✅ |  |
-| `Model.objects.ausing`              | ✅ |  |
-| `Model.objects.aresolve_expression` | ✅ |  |
-| `Model.objects.aordered`            | ✅ |  |
-| `__aiter__`                              | ✅ |  |
-| `__repr__`                               | ✅ |  |
-| `__len__`                                | ✅ |  |
-| `__getitem__`                            | ✅ |  |
-| `Model.objects.aiterator`           | ❌ |  |
+| methods                             | supported | comments |
+| ----------------------------------- | --------- | -------- |
+| `Model.objects.aget`                | ✅        |          |
+| `Model.objects.acreate`             | ✅        |          |
+| `Model.objects.acount`              | ✅        |          |
+| `Model.objects.anone`               | ✅        |          |
+| `Model.objects.abulk_create`        | ✅        |          |
+| `Model.objects.abulk_update`        | ✅        |          |
+| `Model.objects.aget_or_create`      | ✅        |          |
+| `Model.objects.aupdate_or_create`   | ✅        |          |
+| `Model.objects.aearliest`           | ✅        |          |
+| `Model.objects.alatest`             | ✅        |          |
+| `Model.objects.afirst`              | ✅        |          |
+| `Model.objects.alast`               | ✅        |          |
+| `Model.objects.ain_bulk`            | ✅        |          |
+| `Model.objects.adelete`             | ✅        |          |
+| `Model.objects.aupdate`             | ✅        |          |
+| `Model.objects.aexists`             | ✅        |          |
+| `Model.objects.aexplain`            | ✅        |          |
+| `Model.objects.araw`                | ✅        |          |
+| `Model.objects.aall`                | ✅        |          |
+| `Model.objects.afilter`             | ✅        |          |
+| `Model.objects.aexclude`            | ✅        |          |
+| `Model.objects.acomplex_filter`     | ✅        |          |
+| `Model.objects.aunion`              | ✅        |          |
+| `Model.objects.aintersection`       | ✅        |          |
+| `Model.objects.adifference`         | ✅        |          |
+| `Model.objects.aselect_for_update`  | ✅        |          |
+| `Model.objects.aprefetch_related`   | ✅        |          |
+| `Model.objects.aannotate`           | ✅        |          |
+| `Model.objects.aorder_by`           | ✅        |          |
+| `Model.objects.adistinct`           | ✅        |          |
+| `Model.objects.adifference`         | ✅        |          |
+| `Model.objects.aextra`              | ✅        |          |
+| `Model.objects.areverse`            | ✅        |          |
+| `Model.objects.adefer`              | ✅        |          |
+| `Model.objects.aonly`               | ✅        |          |
+| `Model.objects.ausing`              | ✅        |          |
+| `Model.objects.aresolve_expression` | ✅        |          |
+| `Model.objects.aordered`            | ✅        |          |
+| `__aiter__`                         | ✅        |          |
+| `__repr__`                          | ✅        |          |
+| `__len__`                           | ✅        |          |
+| `__getitem__`                       | ✅        |          |
+| `Model.objects.aiterator`           | ❌        |          |
 
 ### RawQuerySet
+
 Not supported ❌
 
 You can still call `Model.object.araw()` but you will be unable to access the results.
 
 ### Model:
 
-| methods                    | supported  | comments |
-|----------------------------|------------|----------|
-| `Model.asave`                      | ❌ |  |
-| `Model.aupdate`                    | ❌ |  |
-| `Model.adelete`                    | ❌ |  |
-| `...`                                   | ❌ |  |
-
+| methods         | supported | comments |
+| --------------- | --------- | -------- |
+| `Model.asave`   | ❌        |          |
+| `Model.aupdate` | ❌        |          |
+| `Model.adelete` | ❌        |          |
+| `...`           | ❌        |          |
 
 ### User Model / Manager
-| methods                    | supported  | comments |
-|----------------------------|------------|----------|
-| `UserModel.is_authenticated`            | ✅ |  |
-| `UserModel.is_super_user`               | ✅ |  |
-| `UserModel.objects.acreate_user`   | ❌ |  |
-| `...`                                   | ❌ |  |
 
+| methods                     | supported | comments |
+| --------------------------- | --------- | -------- |
+| `User.is_authenticated`     | ✅        |          |
+| `User.is_super_user`        | ✅        |          |
+| `User.objects.acreate_user` | ❌        |          |
+| `...`                       | ❌        |          |
 
 ### Foreign object lazy loading:
+
 Not supported ❌
 
-
 ### Wrappers:
-| methods                    | supported  | comments |
-|----------------------------|------------|----------|
-| `wrappers.arender`            | ✅  |  |
-| `wrappers.alogin`            | ✅  |  |
-| `wrappers.alogout`            | ✅  |  |
 
-
-
+| methods   | supported | comments |
+| --------- | --------- | -------- |
+| `arender` | ✅        |          |
+| `alogin`  | ✅        |          |
+| `alogout` | ✅        |          |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ INSTALLED_APPS = [
 # Usage
 
 Django Async Orm will patch all your existing models to add `async_*` prefixed methods.
-To be
+
+_note:_ Only non-existing methods will be patched.
 
 example:
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ you can use it as follow:
 
 ```python
 async def get_model():
-    return await  MyModel.objects.async_get(name="something")
+    return await  MyModel.objects.aget(name="something")
 ```
 
 you can also iterate over a query set with `async for`:
 
 ```python
 async def all_models():
-    all_result_set = await MyModel.objects.async_all()
+    all_result_set = await MyModel.objects.aall()
     async for obj in all_result_set:
         print(obj)
 ```
@@ -52,20 +52,20 @@ Some wrappers are also available for template rendering, form validation and log
 
 #### Async login
 ```python
-from django_async_orm.wrappers import async_login
+from django_async_orm.wrappers import alogin
 
 async def my_async_view(request):
-    await async_login(request)
+    await alogin(request)
     ...
 ```
 
 #### Form validation
 ```python
 
-from django_async_orm.wrappers import async_form_is_valid
+from django_async_orm.wrappers import aform_is_valid
 async def a_view(request):
     form = MyForm(request.POST)
-    is_valid_form = await async_form_is_valid(form)
+    is_valid_form = await aform_is_valid(form)
     if is_valid_form:
         ...
     
@@ -80,62 +80,62 @@ This is an on going projects, not all model methods are ported.
 
 | methods                                  | supported  | comments |
 |------------------------------------------|------------|----------|
-| `Model.objects.async_get`                | ✅ |  |
-| `Model.objects.async_create`             | ✅ |  |
-| `Model.objects.async_count`              | ✅ |  |
-| `Model.objects.async_none`               | ✅ |  |
-| `Model.objects.async_bulk_create`        | ✅ |  |
-| `Model.objects.async_bulk_update`        | ✅ |  |
-| `Model.objects.async_get_or_create`      | ✅ |  |
-| `Model.objects.async_update_or_create`   | ✅ |  |
-| `Model.objects.async_earliest`           | ✅ |  |
-| `Model.objects.async_latest`             | ✅ |  |
-| `Model.objects.async_first`              | ✅ |  |
-| `Model.objects.async_last`               | ✅ |  |
-| `Model.objects.async_in_bulk`            | ✅ |  |
-| `Model.objects.async_delete`             | ✅ |  |
-| `Model.objects.async_update`             | ✅ |  |
-| `Model.objects.async_exists`             | ✅ |  |
-| `Model.objects.async_explain`            | ✅ |  |
-| `Model.objects.async_raw`                | ✅ |  |
-| `Model.objects.async_all`                | ✅ |  |
-| `Model.objects.async_filter`             | ✅ |  |
-| `Model.objects.async_exclude`            | ✅ |  |
-| `Model.objects.async_complex_filter`     | ✅ |  |
-| `Model.objects.async_union`              | ✅ |  |
-| `Model.objects.async_intersection`       | ✅ |  |
-| `Model.objects.async_difference`         | ✅ |  |
-| `Model.objects.async_select_for_update`  | ✅ |  |
-| `Model.objects.async_prefetch_related`   | ✅ |  |
-| `Model.objects.async_annotate`           | ✅ |  |
-| `Model.objects.async_order_by`           | ✅ |  |
-| `Model.objects.async_distinct`           | ✅ |  |
-| `Model.objects.async_difference`         | ✅ |  |
-| `Model.objects.async_extra`              | ✅ |  |
-| `Model.objects.async_reverse`            | ✅ |  |
-| `Model.objects.async_defer`              | ✅ |  |
-| `Model.objects.async_only`               | ✅ |  |
-| `Model.objects.async_using`              | ✅ |  |
-| `Model.objects.async_resolve_expression` | ✅ |  |
-| `Model.objects.async_ordered`            | ✅ |  |
+| `Model.objects.aget`                | ✅ |  |
+| `Model.objects.acreate`             | ✅ |  |
+| `Model.objects.acount`              | ✅ |  |
+| `Model.objects.anone`               | ✅ |  |
+| `Model.objects.abulk_create`        | ✅ |  |
+| `Model.objects.abulk_update`        | ✅ |  |
+| `Model.objects.aget_or_create`      | ✅ |  |
+| `Model.objects.aupdate_or_create`   | ✅ |  |
+| `Model.objects.aearliest`           | ✅ |  |
+| `Model.objects.alatest`             | ✅ |  |
+| `Model.objects.afirst`              | ✅ |  |
+| `Model.objects.alast`               | ✅ |  |
+| `Model.objects.ain_bulk`            | ✅ |  |
+| `Model.objects.adelete`             | ✅ |  |
+| `Model.objects.aupdate`             | ✅ |  |
+| `Model.objects.aexists`             | ✅ |  |
+| `Model.objects.aexplain`            | ✅ |  |
+| `Model.objects.araw`                | ✅ |  |
+| `Model.objects.aall`                | ✅ |  |
+| `Model.objects.afilter`             | ✅ |  |
+| `Model.objects.aexclude`            | ✅ |  |
+| `Model.objects.acomplex_filter`     | ✅ |  |
+| `Model.objects.aunion`              | ✅ |  |
+| `Model.objects.aintersection`       | ✅ |  |
+| `Model.objects.adifference`         | ✅ |  |
+| `Model.objects.aselect_for_update`  | ✅ |  |
+| `Model.objects.aprefetch_related`   | ✅ |  |
+| `Model.objects.aannotate`           | ✅ |  |
+| `Model.objects.aorder_by`           | ✅ |  |
+| `Model.objects.adistinct`           | ✅ |  |
+| `Model.objects.adifference`         | ✅ |  |
+| `Model.objects.aextra`              | ✅ |  |
+| `Model.objects.areverse`            | ✅ |  |
+| `Model.objects.adefer`              | ✅ |  |
+| `Model.objects.aonly`               | ✅ |  |
+| `Model.objects.ausing`              | ✅ |  |
+| `Model.objects.aresolve_expression` | ✅ |  |
+| `Model.objects.aordered`            | ✅ |  |
 | `__aiter__`                              | ✅ |  |
 | `__repr__`                               | ✅ |  |
 | `__len__`                                | ✅ |  |
 | `__getitem__`                            | ✅ |  |
-| `Model.objects.async_iterator`           | ❌ |  |
+| `Model.objects.aiterator`           | ❌ |  |
 
 ### RawQuerySet
 Not supported ❌
 
-You can still call `Model.object.async_raw()` but you will be unable to access the results.
+You can still call `Model.object.araw()` but you will be unable to access the results.
 
 ### Model:
 
 | methods                    | supported  | comments |
 |----------------------------|------------|----------|
-| `Model.async_save`                      | ❌ |  |
-| `Model.async_update`                    | ❌ |  |
-| `Model.async_delete`                    | ❌ |  |
+| `Model.asave`                      | ❌ |  |
+| `Model.aupdate`                    | ❌ |  |
+| `Model.adelete`                    | ❌ |  |
 | `...`                                   | ❌ |  |
 
 
@@ -144,7 +144,7 @@ You can still call `Model.object.async_raw()` but you will be unable to access t
 |----------------------------|------------|----------|
 | `UserModel.is_authenticated`            | ✅ |  |
 | `UserModel.is_super_user`               | ✅ |  |
-| `UserModel.objects.async_create_user`   | ❌ |  |
+| `UserModel.objects.acreate_user`   | ❌ |  |
 | `...`                                   | ❌ |  |
 
 
@@ -155,9 +155,9 @@ Not supported ❌
 ### Wrappers:
 | methods                    | supported  | comments |
 |----------------------------|------------|----------|
-| `wrappers.async_render`            | ✅  |  |
-| `wrappers.async_login`            | ✅  |  |
-| `wrappers.async_logout`            | ✅  |  |
+| `wrappers.arender`            | ✅  |  |
+| `wrappers.alogin`            | ✅  |  |
+| `wrappers.alogout`            | ✅  |  |
 
 
 

--- a/django_async_orm/apps.py
+++ b/django_async_orm/apps.py
@@ -9,7 +9,7 @@ class AsyncOrmConfig(AppConfig):
     name = "django_async_orm"
 
     def ready(self):
-        logging.info("AsyncORM: patching models")
+        logging.info("Patching models to add async ORM capabilities...")
         for model in apps.get_models(include_auto_created=True):
             patch_manager(model)
             # TODO: patch_model(model)

--- a/django_async_orm/iter.py
+++ b/django_async_orm/iter.py
@@ -11,7 +11,7 @@ class AsyncIter:
     async def __anext__(self):
         try:
             element = next(self._iter)
-        except StopIteration as e:
-            raise StopAsyncIteration from e
+        except StopIteration:
+            raise StopAsyncIteration
         await asyncio.sleep(0)
         return element

--- a/django_async_orm/iter.py
+++ b/django_async_orm/iter.py
@@ -11,7 +11,7 @@ class AsyncIter:
     async def __anext__(self):
         try:
             element = next(self._iter)
-        except StopIteration:
-            raise StopAsyncIteration
+        except StopIteration as e:
+            raise StopAsyncIteration from e
         await asyncio.sleep(0)
         return element

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -4,9 +4,200 @@ from channels.db import database_sync_to_async as sync_to_async
 from django.db.models import QuerySet
 
 from django_async_orm.iter import AsyncIter
+import inspect
+import warnings
 
 
-class QuerySetAsync(QuerySet):
+class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
+    """
+    These methods will be removed in a future release.
+    Do not edit this class to add new methods.
+    """
+
+    def __init__(self, model=None, query=None, using=None, hints=None):
+        super().__init__(model, query, using, hints)
+
+        # Add deprecation warning to all `async_*` methods
+        for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+            if not name.startswith("async_"):
+                continue
+
+            def wrapper(*args, **kwargs):
+                warnings.warn(
+                    "Methods starting with `async_*` are deprecated and will be "
+                    "removed in a future release. Use `a*` methods instead.",
+                    category=DeprecationWarning,
+                    stacklevel=2,
+                )
+                return method(*args, **kwargs)
+
+            setattr(self, name, wrapper)
+
+    async def async_get(self, *args, **kwargs):
+        return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
+
+    async def async_create(self, **kwargs):
+        return await sync_to_async(self.create, thread_sensitive=True)(**kwargs)
+
+    async def async_bulk_create(self, obs, batch_size=None, ignore_conflicts=False):
+        return await sync_to_async(self.bulk_create, thread_sensitive=True)(
+            obs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
+        )
+
+    async def async_bulk_update(self, objs, fields, batch_size=None):
+        return await sync_to_async(self.bulk_update, thread_sensitive=True)(
+            objs=objs, fields=fields, batch_size=batch_size
+        )
+
+    async def async_get_or_create(self, defaults=None, **kwargs):
+        return await sync_to_async(self.get_or_create, thread_sensitive=True)(
+            defaults=defaults, **kwargs
+        )
+
+    async def async_update_or_create(self, defaults=None, **kwargs):
+        return await sync_to_async(self.update_or_create, thread_sensitive=True)(
+            defaults=defaults, **kwargs
+        )
+
+    async def async_earliest(self, *fields):
+        return await sync_to_async(self.earliest, thread_sensitive=True)(*fields)
+
+    async def async_latest(self, *fields):
+        return await sync_to_async(self.latest, thread_sensitive=True)(*fields)
+
+    async def async_first(self):
+        return await sync_to_async(self.first, thread_sensitive=True)()
+
+    async def async_none(self):
+        return await sync_to_async(self.none, thread_sensitive=True)()
+
+    async def async_last(self):
+        return await sync_to_async(self.last, thread_sensitive=True)()
+
+    async def async_in_bulk(self, id_list=None, *_, field_name="pk"):
+        return await sync_to_async(self.in_bulk, thread_sensitive=True)(
+            id_list=id_list, *_, field_name=field_name
+        )
+
+    async def async_delete(self):
+        return await sync_to_async(self.delete, thread_sensitive=True)()
+
+    async def async_update(self, **kwargs):
+        return await sync_to_async(self.update, thread_sensitive=True)(**kwargs)
+
+    async def async_exists(self):
+        return await sync_to_async(self.exists, thread_sensitive=True)()
+
+    async def async_count(self):
+        return await sync_to_async(self.count, thread_sensitive=True)()
+
+    async def async_explain(self, *_, format=None, **options):
+        return await sync_to_async(self.explain, thread_sensitive=True)(
+            *_, format=format, **options
+        )
+
+    async def async_raw(self, raw_query, params=None, translations=None, using=None):
+        return await sync_to_async(self.raw, thread_sensitive=True)(
+            raw_query, params=params, translations=translations, using=using
+        )
+
+    def __aiter__(self):
+        self._fetch_all()
+        return AsyncIter(self._result_cache)
+
+    def _fetch_all(self):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future_fetch_all = executor.submit(super(QuerySetAsync, self)._fetch_all)
+
+    ##################################################################
+    # PUBLIC METHODS THAT ALTER ATTRIBUTES AND RETURN A NEW QUERYSET #
+    ##################################################################
+
+    async def async_all(self):
+        return await sync_to_async(self.all, thread_sensitive=True)()
+
+    async def async_filter(self, *args, **kwargs):
+        return await sync_to_async(self.filter, thread_sensitive=True)(*args, **kwargs)
+
+    async def async_exclude(self, *args, **kwargs):
+        return await sync_to_async(self.exclude, thread_sensitive=True)(*args, **kwargs)
+
+    async def async_complex_filter(self, filter_obj):
+        return await sync_to_async(self.complex_filter, thread_sensitive=True)(
+            filter_obj
+        )
+
+    async def async_union(self, *other_qs, all=False):
+        return await sync_to_async(self.union, thread_sensitive=True)(
+            *other_qs, all=all
+        )
+
+    async def async_intersection(self, *other_qs):
+        return await sync_to_async(self.intersection, thread_sensitive=True)(*other_qs)
+
+    async def async_difference(self, *other_qs):
+        return await sync_to_async(self.difference, thread_sensitive=True)(*other_qs)
+
+    async def async_select_for_update(self, nowait=False, skip_locked=False, of=()):
+        return await sync_to_async(self.select_for_update, thread_sensitive=True)(
+            nowait=nowait, skip_locked=skip_locked, of=of
+        )
+
+    async def async_prefetch_related(self, *lookups):
+        return await sync_to_async(self.prefetch_related, thread_sensitive=True)(
+            *lookups
+        )
+
+    async def async_annotate(self, *args, **kwargs):
+        return await sync_to_async(self.annotate, thread_sensitive=True)(
+            *args, **kwargs
+        )
+
+    async def async_order_by(self, *field_names):
+        return await sync_to_async(self.order_by, thread_sensitive=True)(*field_names)
+
+    async def async_distinct(self, *field_names):
+        return await sync_to_async(self.distinct, thread_sensitive=True)(*field_names)
+
+    async def async_extra(
+        self,
+        select=None,
+        where=None,
+        params=None,
+        tables=None,
+        order_by=None,
+        select_params=None,
+    ):
+        return await sync_to_async(self.extra, thread_sensitive=True)(
+            select, where, params, tables, order_by, select_params
+        )
+
+    async def async_reverse(self):
+        return await sync_to_async(self.reverse, thread_sensitive=True)()
+
+    async def async_defer(self, *fields):
+        return await sync_to_async(self.defer, thread_sensitive=True)(*fields)
+
+    async def async_only(self, *fields):
+        return await sync_to_async(self.only, thread_sensitive=True)(*fields)
+
+    async def async_using(self, alias):
+        return await sync_to_async(self.using, thread_sensitive=True)(alias)
+
+    async def async_resolve_expression(self, *args, **kwargs):
+        return await sync_to_async(self.resolve_expression, thread_sensitive=True)(
+            *args, **kwargs
+        )
+
+    @property
+    async def async_ordered(self):
+        def _ordered():
+            return super(QuerySetAsync, self).ordered
+
+        return await sync_to_async(_ordered, thread_sensitive=True)()
+
+
+class QuerySetAsync(__LegacyQuerySetAsync):
     def __init__(self, model=None, query=None, using=None, hints=None):
         super().__init__(model, query, using, hints)
 

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -23,14 +23,14 @@ class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
 
             method = getattr(self, name)
 
-            def wrapper(*args, **kwargs):
+            async def wrapper(*args, **kwargs):
                 warnings.warn(
                     "Methods starting with `async_*` are deprecated and will be "
                     "removed in a future release. Use `a*` methods instead.",
                     category=DeprecationWarning,
                     stacklevel=2,
                 )
-                return method(*args, **kwargs)
+                return await method(*args, **kwargs)
 
             setattr(self, name, wrapper)
 

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -35,7 +35,7 @@ class QuerySetAsync(QuerySet):
 
     @_priortize_django
     async def aget(self, *args, **kwargs):
-        return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
+        return await sync_to_async(self.get, thread_sensitive=True)(*args, **kwargs)
 
     @_priortize_django
     async def acreate(self, **kwargs):
@@ -240,7 +240,7 @@ class QuerySetAsync(QuerySet):
 
     async def async_get(self, *args, **kwargs):
         __deprecation_warning()
-        return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
+        return await sync_to_async(self.get, thread_sensitive=True)(*args, **kwargs)
 
     async def async_create(self, **kwargs):
         __deprecation_warning()

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -1,5 +1,4 @@
 import concurrent
-import inspect
 import warnings
 
 from channels.db import database_sync_to_async as sync_to_async
@@ -18,9 +17,11 @@ class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
         super().__init__(model, query, using, hints)
 
         # Add deprecation warning to all `async_*` methods
-        for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+        for name in dir(self):
             if not name.startswith("async_"):
                 continue
+
+            method = getattr(self, name)
 
             def wrapper(*args, **kwargs):
                 warnings.warn(

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -16,7 +16,7 @@ def __deprecation_warning():
     )
 
 
-def _priortize_django(method):
+def _prefer_django(method):
     """Decorator used to prioritize Django's QuerySet methods over our custom ones.
 
     This will help maintain performance when Django adds real async support."""
@@ -33,93 +33,93 @@ class QuerySetAsync(QuerySet):
     def __init__(self, model=None, query=None, using=None, hints=None):
         super().__init__(model, query, using, hints)
 
-    @_priortize_django
+    @_prefer_django
     async def aget(self, *args, **kwargs):
         return await sync_to_async(self.get, thread_sensitive=True)(*args, **kwargs)
 
-    @_priortize_django
+    @_prefer_django
     async def acreate(self, **kwargs):
         return await sync_to_async(self.create, thread_sensitive=True)(**kwargs)
 
-    @_priortize_django
+    @_prefer_django
     async def abulk_create(self, obs, batch_size=None, ignore_conflicts=False):
         return await sync_to_async(self.bulk_create, thread_sensitive=True)(
             obs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
 
-    @_priortize_django
+    @_prefer_django
     async def abulk_update(self, objs, fields, batch_size=None):
         return await sync_to_async(self.bulk_update, thread_sensitive=True)(
             objs=objs, fields=fields, batch_size=batch_size
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aget_or_create(self, defaults=None, **kwargs):
         return await sync_to_async(self.get_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aupdate_or_create(self, defaults=None, **kwargs):
         return await sync_to_async(self.update_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aearliest(self, *fields):
         return await sync_to_async(self.earliest, thread_sensitive=True)(*fields)
 
-    @_priortize_django
+    @_prefer_django
     async def alatest(self, *fields):
         return await sync_to_async(self.latest, thread_sensitive=True)(*fields)
 
-    @_priortize_django
+    @_prefer_django
     async def afirst(self):
         return await sync_to_async(self.first, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def anone(self):
         return await sync_to_async(self.none, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def alast(self):
         return await sync_to_async(self.last, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def ain_bulk(self, id_list=None, *_, field_name="pk"):
         return await sync_to_async(self.in_bulk, thread_sensitive=True)(
             id_list=id_list, *_, field_name=field_name
         )
 
-    @_priortize_django
+    @_prefer_django
     async def adelete(self):
         return await sync_to_async(self.delete, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def aupdate(self, **kwargs):
         return await sync_to_async(self.update, thread_sensitive=True)(**kwargs)
 
-    @_priortize_django
+    @_prefer_django
     async def aexists(self):
         return await sync_to_async(self.exists, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def acount(self):
         return await sync_to_async(self.count, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def aexplain(self, *_, format=None, **options):
         return await sync_to_async(self.explain, thread_sensitive=True)(
             *_, format=format, **options
         )
 
-    @_priortize_django
+    @_prefer_django
     async def araw(self, raw_query, params=None, translations=None, using=None):
         return await sync_to_async(self.raw, thread_sensitive=True)(
             raw_query, params=params, translations=translations, using=using
         )
 
-    @_priortize_django
+    @_prefer_django
     def __aiter__(self):
         self._fetch_all()
         return AsyncIter(self._result_cache)
@@ -132,65 +132,65 @@ class QuerySetAsync(QuerySet):
     # PUBLIC METHODS THAT ALTER ATTRIBUTES AND RETURN A NEW QUERYSET #
     ##################################################################
 
-    @_priortize_django
+    @_prefer_django
     async def aall(self):
         return await sync_to_async(self.all, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def afilter(self, *args, **kwargs):
         return await sync_to_async(self.filter, thread_sensitive=True)(*args, **kwargs)
 
-    @_priortize_django
+    @_prefer_django
     async def aexclude(self, *args, **kwargs):
         return await sync_to_async(self.exclude, thread_sensitive=True)(*args, **kwargs)
 
-    @_priortize_django
+    @_prefer_django
     async def acomplex_filter(self, filter_obj):
         return await sync_to_async(self.complex_filter, thread_sensitive=True)(
             filter_obj
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aunion(self, *other_qs, all=False):
         return await sync_to_async(self.union, thread_sensitive=True)(
             *other_qs, all=all
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aintersection(self, *other_qs):
         return await sync_to_async(self.intersection, thread_sensitive=True)(*other_qs)
 
-    @_priortize_django
+    @_prefer_django
     async def adifference(self, *other_qs):
         return await sync_to_async(self.difference, thread_sensitive=True)(*other_qs)
 
-    @_priortize_django
+    @_prefer_django
     async def aselect_for_update(self, nowait=False, skip_locked=False, of=()):
         return await sync_to_async(self.select_for_update, thread_sensitive=True)(
             nowait=nowait, skip_locked=skip_locked, of=of
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aprefetch_related(self, *lookups):
         return await sync_to_async(self.prefetch_related, thread_sensitive=True)(
             *lookups
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aannotate(self, *args, **kwargs):
         return await sync_to_async(self.annotate, thread_sensitive=True)(
             *args, **kwargs
         )
 
-    @_priortize_django
+    @_prefer_django
     async def aorder_by(self, *field_names):
         return await sync_to_async(self.order_by, thread_sensitive=True)(*field_names)
 
-    @_priortize_django
+    @_prefer_django
     async def adistinct(self, *field_names):
         return await sync_to_async(self.distinct, thread_sensitive=True)(*field_names)
 
-    @_priortize_django
+    @_prefer_django
     async def aextra(
         self,
         select=None,
@@ -204,30 +204,30 @@ class QuerySetAsync(QuerySet):
             select, where, params, tables, order_by, select_params
         )
 
-    @_priortize_django
+    @_prefer_django
     async def areverse(self):
         return await sync_to_async(self.reverse, thread_sensitive=True)()
 
-    @_priortize_django
+    @_prefer_django
     async def adefer(self, *fields):
         return await sync_to_async(self.defer, thread_sensitive=True)(*fields)
 
-    @_priortize_django
+    @_prefer_django
     async def aonly(self, *fields):
         return await sync_to_async(self.only, thread_sensitive=True)(*fields)
 
-    @_priortize_django
+    @_prefer_django
     async def ausing(self, alias):
         return await sync_to_async(self.using, thread_sensitive=True)(alias)
 
-    @_priortize_django
+    @_prefer_django
     async def aresolve_expression(self, *args, **kwargs):
         return await sync_to_async(self.resolve_expression, thread_sensitive=True)(
             *args, **kwargs
         )
 
     @property
-    @_priortize_django
+    @_prefer_django
     async def aordered(self):
         def _ordered():
             return super(QuerySetAsync, self).ordered

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -7,6 +7,15 @@ from django.db.models import QuerySet
 from django_async_orm.iter import AsyncIter
 
 
+def __deprecation_warning():
+    warnings.warn(
+        "Methods starting with `async_*` are deprecated and will be "
+        "removed in a future release. Use `a*` methods instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+
 class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
     """
     These methods will be removed in a future release.
@@ -16,88 +25,88 @@ class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
     def __init__(self, model=None, query=None, using=None, hints=None):
         super().__init__(model, query, using, hints)
 
-        # Add deprecation warning to all `async_*` methods
-        for name in dir(self):
-            if not name.startswith("async_"):
-                continue
-
-            method = getattr(self, name)
-
-            async def wrapper(*args, **kwargs):
-                warnings.warn(
-                    "Methods starting with `async_*` are deprecated and will be "
-                    "removed in a future release. Use `a*` methods instead.",
-                    category=DeprecationWarning,
-                    stacklevel=2,
-                )
-                return await method(*args, **kwargs)
-
-            setattr(self, name, wrapper)
-
     async def async_get(self, *args, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
 
     async def async_create(self, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.create, thread_sensitive=True)(**kwargs)
 
     async def async_bulk_create(self, obs, batch_size=None, ignore_conflicts=False):
+        __deprecation_warning()
         return await sync_to_async(self.bulk_create, thread_sensitive=True)(
             obs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
 
     async def async_bulk_update(self, objs, fields, batch_size=None):
+        __deprecation_warning()
         return await sync_to_async(self.bulk_update, thread_sensitive=True)(
             objs=objs, fields=fields, batch_size=batch_size
         )
 
     async def async_get_or_create(self, defaults=None, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.get_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
     async def async_update_or_create(self, defaults=None, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.update_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
     async def async_earliest(self, *fields):
+        __deprecation_warning()
         return await sync_to_async(self.earliest, thread_sensitive=True)(*fields)
 
     async def async_latest(self, *fields):
+        __deprecation_warning()
         return await sync_to_async(self.latest, thread_sensitive=True)(*fields)
 
     async def async_first(self):
+        __deprecation_warning()
         return await sync_to_async(self.first, thread_sensitive=True)()
 
     async def async_none(self):
+        __deprecation_warning()
         return await sync_to_async(self.none, thread_sensitive=True)()
 
     async def async_last(self):
+        __deprecation_warning()
         return await sync_to_async(self.last, thread_sensitive=True)()
 
     async def async_in_bulk(self, id_list=None, *_, field_name="pk"):
+        __deprecation_warning()
         return await sync_to_async(self.in_bulk, thread_sensitive=True)(
             id_list=id_list, *_, field_name=field_name
         )
 
     async def async_delete(self):
+        __deprecation_warning()
         return await sync_to_async(self.delete, thread_sensitive=True)()
 
     async def async_update(self, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.update, thread_sensitive=True)(**kwargs)
 
     async def async_exists(self):
+        __deprecation_warning()
         return await sync_to_async(self.exists, thread_sensitive=True)()
 
     async def async_count(self):
+        __deprecation_warning()
         return await sync_to_async(self.count, thread_sensitive=True)()
 
     async def async_explain(self, *_, format=None, **options):
+        __deprecation_warning()
         return await sync_to_async(self.explain, thread_sensitive=True)(
             *_, format=format, **options
         )
 
     async def async_raw(self, raw_query, params=None, translations=None, using=None):
+        __deprecation_warning()
         return await sync_to_async(self.raw, thread_sensitive=True)(
             raw_query, params=params, translations=translations, using=using
         )
@@ -115,49 +124,61 @@ class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
     ##################################################################
 
     async def async_all(self):
+        __deprecation_warning()
         return await sync_to_async(self.all, thread_sensitive=True)()
 
     async def async_filter(self, *args, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.filter, thread_sensitive=True)(*args, **kwargs)
 
     async def async_exclude(self, *args, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.exclude, thread_sensitive=True)(*args, **kwargs)
 
     async def async_complex_filter(self, filter_obj):
+        __deprecation_warning()
         return await sync_to_async(self.complex_filter, thread_sensitive=True)(
             filter_obj
         )
 
     async def async_union(self, *other_qs, all=False):
+        __deprecation_warning()
         return await sync_to_async(self.union, thread_sensitive=True)(
             *other_qs, all=all
         )
 
     async def async_intersection(self, *other_qs):
+        __deprecation_warning()
         return await sync_to_async(self.intersection, thread_sensitive=True)(*other_qs)
 
     async def async_difference(self, *other_qs):
+        __deprecation_warning()
         return await sync_to_async(self.difference, thread_sensitive=True)(*other_qs)
 
     async def async_select_for_update(self, nowait=False, skip_locked=False, of=()):
+        __deprecation_warning()
         return await sync_to_async(self.select_for_update, thread_sensitive=True)(
             nowait=nowait, skip_locked=skip_locked, of=of
         )
 
     async def async_prefetch_related(self, *lookups):
+        __deprecation_warning()
         return await sync_to_async(self.prefetch_related, thread_sensitive=True)(
             *lookups
         )
 
     async def async_annotate(self, *args, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.annotate, thread_sensitive=True)(
             *args, **kwargs
         )
 
     async def async_order_by(self, *field_names):
+        __deprecation_warning()
         return await sync_to_async(self.order_by, thread_sensitive=True)(*field_names)
 
     async def async_distinct(self, *field_names):
+        __deprecation_warning()
         return await sync_to_async(self.distinct, thread_sensitive=True)(*field_names)
 
     async def async_extra(
@@ -169,29 +190,36 @@ class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
         order_by=None,
         select_params=None,
     ):
+        __deprecation_warning()
         return await sync_to_async(self.extra, thread_sensitive=True)(
             select, where, params, tables, order_by, select_params
         )
 
     async def async_reverse(self):
+        __deprecation_warning()
         return await sync_to_async(self.reverse, thread_sensitive=True)()
 
     async def async_defer(self, *fields):
+        __deprecation_warning()
         return await sync_to_async(self.defer, thread_sensitive=True)(*fields)
 
     async def async_only(self, *fields):
+        __deprecation_warning()
         return await sync_to_async(self.only, thread_sensitive=True)(*fields)
 
     async def async_using(self, alias):
+        __deprecation_warning()
         return await sync_to_async(self.using, thread_sensitive=True)(alias)
 
     async def async_resolve_expression(self, *args, **kwargs):
+        __deprecation_warning()
         return await sync_to_async(self.resolve_expression, thread_sensitive=True)(
             *args, **kwargs
         )
 
     @property
     async def async_ordered(self):
+        __deprecation_warning()
         def _ordered():
             return super(QuerySetAsync, self).ordered
 

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -10,70 +10,70 @@ class QuerySetAsync(QuerySet):
     def __init__(self, model=None, query=None, using=None, hints=None):
         super().__init__(model, query, using, hints)
 
-    async def async_get(self, *args, **kwargs):
+    async def aget(self, *args, **kwargs):
         return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
 
-    async def async_create(self, **kwargs):
+    async def acreate(self, **kwargs):
         return await sync_to_async(self.create, thread_sensitive=True)(**kwargs)
 
-    async def async_bulk_create(self, obs, batch_size=None, ignore_conflicts=False):
+    async def abulk_create(self, obs, batch_size=None, ignore_conflicts=False):
         return await sync_to_async(self.bulk_create, thread_sensitive=True)(
             obs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
 
-    async def async_bulk_update(self, objs, fields, batch_size=None):
+    async def abulk_update(self, objs, fields, batch_size=None):
         return await sync_to_async(self.bulk_update, thread_sensitive=True)(
             objs=objs, fields=fields, batch_size=batch_size
         )
 
-    async def async_get_or_create(self, defaults=None, **kwargs):
+    async def aget_or_create(self, defaults=None, **kwargs):
         return await sync_to_async(self.get_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
-    async def async_update_or_create(self, defaults=None, **kwargs):
+    async def aupdate_or_create(self, defaults=None, **kwargs):
         return await sync_to_async(self.update_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
-    async def async_earliest(self, *fields):
+    async def aearliest(self, *fields):
         return await sync_to_async(self.earliest, thread_sensitive=True)(*fields)
 
-    async def async_latest(self, *fields):
+    async def alatest(self, *fields):
         return await sync_to_async(self.latest, thread_sensitive=True)(*fields)
 
-    async def async_first(self):
+    async def afirst(self):
         return await sync_to_async(self.first, thread_sensitive=True)()
 
-    async def async_none(self):
+    async def anone(self):
         return await sync_to_async(self.none, thread_sensitive=True)()
 
-    async def async_last(self):
+    async def alast(self):
         return await sync_to_async(self.last, thread_sensitive=True)()
 
-    async def async_in_bulk(self, id_list=None, *_, field_name="pk"):
+    async def ain_bulk(self, id_list=None, *_, field_name="pk"):
         return await sync_to_async(self.in_bulk, thread_sensitive=True)(
             id_list=id_list, *_, field_name=field_name
         )
 
-    async def async_delete(self):
+    async def adelete(self):
         return await sync_to_async(self.delete, thread_sensitive=True)()
 
-    async def async_update(self, **kwargs):
+    async def aupdate(self, **kwargs):
         return await sync_to_async(self.update, thread_sensitive=True)(**kwargs)
 
-    async def async_exists(self):
+    async def aexists(self):
         return await sync_to_async(self.exists, thread_sensitive=True)()
 
-    async def async_count(self):
+    async def acount(self):
         return await sync_to_async(self.count, thread_sensitive=True)()
 
-    async def async_explain(self, *_, format=None, **options):
+    async def aexplain(self, *_, format=None, **options):
         return await sync_to_async(self.explain, thread_sensitive=True)(
             *_, format=format, **options
         )
 
-    async def async_raw(self, raw_query, params=None, translations=None, using=None):
+    async def araw(self, raw_query, params=None, translations=None, using=None):
         return await sync_to_async(self.raw, thread_sensitive=True)(
             raw_query, params=params, translations=translations, using=using
         )
@@ -90,53 +90,53 @@ class QuerySetAsync(QuerySet):
     # PUBLIC METHODS THAT ALTER ATTRIBUTES AND RETURN A NEW QUERYSET #
     ##################################################################
 
-    async def async_all(self):
+    async def aall(self):
         return await sync_to_async(self.all, thread_sensitive=True)()
 
-    async def async_filter(self, *args, **kwargs):
+    async def afilter(self, *args, **kwargs):
         return await sync_to_async(self.filter, thread_sensitive=True)(*args, **kwargs)
 
-    async def async_exclude(self, *args, **kwargs):
+    async def aexclude(self, *args, **kwargs):
         return await sync_to_async(self.exclude, thread_sensitive=True)(*args, **kwargs)
 
-    async def async_complex_filter(self, filter_obj):
+    async def acomplex_filter(self, filter_obj):
         return await sync_to_async(self.complex_filter, thread_sensitive=True)(
             filter_obj
         )
 
-    async def async_union(self, *other_qs, all=False):
+    async def aunion(self, *other_qs, all=False):
         return await sync_to_async(self.union, thread_sensitive=True)(
             *other_qs, all=all
         )
 
-    async def async_intersection(self, *other_qs):
+    async def aintersection(self, *other_qs):
         return await sync_to_async(self.intersection, thread_sensitive=True)(*other_qs)
 
-    async def async_difference(self, *other_qs):
+    async def adifference(self, *other_qs):
         return await sync_to_async(self.difference, thread_sensitive=True)(*other_qs)
 
-    async def async_select_for_update(self, nowait=False, skip_locked=False, of=()):
+    async def aselect_for_update(self, nowait=False, skip_locked=False, of=()):
         return await sync_to_async(self.select_for_update, thread_sensitive=True)(
             nowait=nowait, skip_locked=skip_locked, of=of
         )
 
-    async def async_prefetch_related(self, *lookups):
+    async def aprefetch_related(self, *lookups):
         return await sync_to_async(self.prefetch_related, thread_sensitive=True)(
             *lookups
         )
 
-    async def async_annotate(self, *args, **kwargs):
+    async def aannotate(self, *args, **kwargs):
         return await sync_to_async(self.annotate, thread_sensitive=True)(
             *args, **kwargs
         )
 
-    async def async_order_by(self, *field_names):
+    async def aorder_by(self, *field_names):
         return await sync_to_async(self.order_by, thread_sensitive=True)(*field_names)
 
-    async def async_distinct(self, *field_names):
+    async def adistinct(self, *field_names):
         return await sync_to_async(self.distinct, thread_sensitive=True)(*field_names)
 
-    async def async_extra(
+    async def aextra(
         self,
         select=None,
         where=None,
@@ -149,25 +149,25 @@ class QuerySetAsync(QuerySet):
             select, where, params, tables, order_by, select_params
         )
 
-    async def async_reverse(self):
+    async def areverse(self):
         return await sync_to_async(self.reverse, thread_sensitive=True)()
 
-    async def async_defer(self, *fields):
+    async def adefer(self, *fields):
         return await sync_to_async(self.defer, thread_sensitive=True)(*fields)
 
-    async def async_only(self, *fields):
+    async def aonly(self, *fields):
         return await sync_to_async(self.only, thread_sensitive=True)(*fields)
 
-    async def async_using(self, alias):
+    async def ausing(self, alias):
         return await sync_to_async(self.using, thread_sensitive=True)(alias)
 
-    async def async_resolve_expression(self, *args, **kwargs):
+    async def aresolve_expression(self, *args, **kwargs):
         return await sync_to_async(self.resolve_expression, thread_sensitive=True)(
             *args, **kwargs
         )
 
     @property
-    async def async_ordered(self):
+    async def aordered(self):
         def _ordered():
             return super(QuerySetAsync, self).ordered
 

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -220,6 +220,7 @@ class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
     @property
     async def async_ordered(self):
         __deprecation_warning()
+
         def _ordered():
             return super(QuerySetAsync, self).ordered
 

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -22,7 +22,9 @@ def _priortize_django(method):
     This will help maintain performance when Django adds real async support."""
 
     def _wrapper(self, *args, **kwargs):
-        return getattr(super(QuerySet, self), method.__name__, method)(self, *args, **kwargs)
+        return getattr(super(QuerySet, self), method.__name__, method)(
+            self, *args, **kwargs
+        )
 
     return _wrapper
 

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -1,11 +1,11 @@
 import concurrent
+import inspect
+import warnings
 
 from channels.db import database_sync_to_async as sync_to_async
 from django.db.models import QuerySet
 
 from django_async_orm.iter import AsyncIter
-import inspect
-import warnings
 
 
 class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -16,78 +16,108 @@ def __deprecation_warning():
     )
 
 
+def _priortize_django(method):
+    """Decorator used to prioritize built-in QuerySet methods over custom ones.
+
+    This will help maintain performance when Django adds real async support."""
+
+    def _wrapper(self, *args, **kwargs):
+        return getattr(super(QuerySet, self), method.__name__, method)(self, *args, **kwargs)
+
+    return _wrapper
+
+
 class QuerySetAsync(QuerySet):
     def __init__(self, model=None, query=None, using=None, hints=None):
         super().__init__(model, query, using, hints)
 
+    @_priortize_django
     async def aget(self, *args, **kwargs):
         return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
 
+    @_priortize_django
     async def acreate(self, **kwargs):
         return await sync_to_async(self.create, thread_sensitive=True)(**kwargs)
 
+    @_priortize_django
     async def abulk_create(self, obs, batch_size=None, ignore_conflicts=False):
         return await sync_to_async(self.bulk_create, thread_sensitive=True)(
             obs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
 
+    @_priortize_django
     async def abulk_update(self, objs, fields, batch_size=None):
         return await sync_to_async(self.bulk_update, thread_sensitive=True)(
             objs=objs, fields=fields, batch_size=batch_size
         )
 
+    @_priortize_django
     async def aget_or_create(self, defaults=None, **kwargs):
         return await sync_to_async(self.get_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
+    @_priortize_django
     async def aupdate_or_create(self, defaults=None, **kwargs):
         return await sync_to_async(self.update_or_create, thread_sensitive=True)(
             defaults=defaults, **kwargs
         )
 
+    @_priortize_django
     async def aearliest(self, *fields):
         return await sync_to_async(self.earliest, thread_sensitive=True)(*fields)
 
+    @_priortize_django
     async def alatest(self, *fields):
         return await sync_to_async(self.latest, thread_sensitive=True)(*fields)
 
+    @_priortize_django
     async def afirst(self):
         return await sync_to_async(self.first, thread_sensitive=True)()
 
+    @_priortize_django
     async def anone(self):
         return await sync_to_async(self.none, thread_sensitive=True)()
 
+    @_priortize_django
     async def alast(self):
         return await sync_to_async(self.last, thread_sensitive=True)()
 
+    @_priortize_django
     async def ain_bulk(self, id_list=None, *_, field_name="pk"):
         return await sync_to_async(self.in_bulk, thread_sensitive=True)(
             id_list=id_list, *_, field_name=field_name
         )
 
+    @_priortize_django
     async def adelete(self):
         return await sync_to_async(self.delete, thread_sensitive=True)()
 
+    @_priortize_django
     async def aupdate(self, **kwargs):
         return await sync_to_async(self.update, thread_sensitive=True)(**kwargs)
 
+    @_priortize_django
     async def aexists(self):
         return await sync_to_async(self.exists, thread_sensitive=True)()
 
+    @_priortize_django
     async def acount(self):
         return await sync_to_async(self.count, thread_sensitive=True)()
 
+    @_priortize_django
     async def aexplain(self, *_, format=None, **options):
         return await sync_to_async(self.explain, thread_sensitive=True)(
             *_, format=format, **options
         )
 
+    @_priortize_django
     async def araw(self, raw_query, params=None, translations=None, using=None):
         return await sync_to_async(self.raw, thread_sensitive=True)(
             raw_query, params=params, translations=translations, using=using
         )
 
+    @_priortize_django
     def __aiter__(self):
         self._fetch_all()
         return AsyncIter(self._result_cache)
@@ -100,52 +130,65 @@ class QuerySetAsync(QuerySet):
     # PUBLIC METHODS THAT ALTER ATTRIBUTES AND RETURN A NEW QUERYSET #
     ##################################################################
 
+    @_priortize_django
     async def aall(self):
         return await sync_to_async(self.all, thread_sensitive=True)()
 
+    @_priortize_django
     async def afilter(self, *args, **kwargs):
         return await sync_to_async(self.filter, thread_sensitive=True)(*args, **kwargs)
 
+    @_priortize_django
     async def aexclude(self, *args, **kwargs):
         return await sync_to_async(self.exclude, thread_sensitive=True)(*args, **kwargs)
 
+    @_priortize_django
     async def acomplex_filter(self, filter_obj):
         return await sync_to_async(self.complex_filter, thread_sensitive=True)(
             filter_obj
         )
 
+    @_priortize_django
     async def aunion(self, *other_qs, all=False):
         return await sync_to_async(self.union, thread_sensitive=True)(
             *other_qs, all=all
         )
 
+    @_priortize_django
     async def aintersection(self, *other_qs):
         return await sync_to_async(self.intersection, thread_sensitive=True)(*other_qs)
 
+    @_priortize_django
     async def adifference(self, *other_qs):
         return await sync_to_async(self.difference, thread_sensitive=True)(*other_qs)
 
+    @_priortize_django
     async def aselect_for_update(self, nowait=False, skip_locked=False, of=()):
         return await sync_to_async(self.select_for_update, thread_sensitive=True)(
             nowait=nowait, skip_locked=skip_locked, of=of
         )
 
+    @_priortize_django
     async def aprefetch_related(self, *lookups):
         return await sync_to_async(self.prefetch_related, thread_sensitive=True)(
             *lookups
         )
 
+    @_priortize_django
     async def aannotate(self, *args, **kwargs):
         return await sync_to_async(self.annotate, thread_sensitive=True)(
             *args, **kwargs
         )
 
+    @_priortize_django
     async def aorder_by(self, *field_names):
         return await sync_to_async(self.order_by, thread_sensitive=True)(*field_names)
 
+    @_priortize_django
     async def adistinct(self, *field_names):
         return await sync_to_async(self.distinct, thread_sensitive=True)(*field_names)
 
+    @_priortize_django
     async def aextra(
         self,
         select=None,
@@ -159,24 +202,30 @@ class QuerySetAsync(QuerySet):
             select, where, params, tables, order_by, select_params
         )
 
+    @_priortize_django
     async def areverse(self):
         return await sync_to_async(self.reverse, thread_sensitive=True)()
 
+    @_priortize_django
     async def adefer(self, *fields):
         return await sync_to_async(self.defer, thread_sensitive=True)(*fields)
 
+    @_priortize_django
     async def aonly(self, *fields):
         return await sync_to_async(self.only, thread_sensitive=True)(*fields)
 
+    @_priortize_django
     async def ausing(self, alias):
         return await sync_to_async(self.using, thread_sensitive=True)(alias)
 
+    @_priortize_django
     async def aresolve_expression(self, *args, **kwargs):
         return await sync_to_async(self.resolve_expression, thread_sensitive=True)(
             *args, **kwargs
         )
 
     @property
+    @_priortize_django
     async def aordered(self):
         def _ordered():
             return super(QuerySetAsync, self).ordered

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -16,218 +16,7 @@ def __deprecation_warning():
     )
 
 
-class __LegacyQuerySetAsync(QuerySet):  # pragma: no cover
-    """
-    These methods will be removed in a future release.
-    Do not edit this class to add new methods.
-    """
-
-    def __init__(self, model=None, query=None, using=None, hints=None):
-        super().__init__(model, query, using, hints)
-
-    async def async_get(self, *args, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
-
-    async def async_create(self, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.create, thread_sensitive=True)(**kwargs)
-
-    async def async_bulk_create(self, obs, batch_size=None, ignore_conflicts=False):
-        __deprecation_warning()
-        return await sync_to_async(self.bulk_create, thread_sensitive=True)(
-            obs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
-        )
-
-    async def async_bulk_update(self, objs, fields, batch_size=None):
-        __deprecation_warning()
-        return await sync_to_async(self.bulk_update, thread_sensitive=True)(
-            objs=objs, fields=fields, batch_size=batch_size
-        )
-
-    async def async_get_or_create(self, defaults=None, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.get_or_create, thread_sensitive=True)(
-            defaults=defaults, **kwargs
-        )
-
-    async def async_update_or_create(self, defaults=None, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.update_or_create, thread_sensitive=True)(
-            defaults=defaults, **kwargs
-        )
-
-    async def async_earliest(self, *fields):
-        __deprecation_warning()
-        return await sync_to_async(self.earliest, thread_sensitive=True)(*fields)
-
-    async def async_latest(self, *fields):
-        __deprecation_warning()
-        return await sync_to_async(self.latest, thread_sensitive=True)(*fields)
-
-    async def async_first(self):
-        __deprecation_warning()
-        return await sync_to_async(self.first, thread_sensitive=True)()
-
-    async def async_none(self):
-        __deprecation_warning()
-        return await sync_to_async(self.none, thread_sensitive=True)()
-
-    async def async_last(self):
-        __deprecation_warning()
-        return await sync_to_async(self.last, thread_sensitive=True)()
-
-    async def async_in_bulk(self, id_list=None, *_, field_name="pk"):
-        __deprecation_warning()
-        return await sync_to_async(self.in_bulk, thread_sensitive=True)(
-            id_list=id_list, *_, field_name=field_name
-        )
-
-    async def async_delete(self):
-        __deprecation_warning()
-        return await sync_to_async(self.delete, thread_sensitive=True)()
-
-    async def async_update(self, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.update, thread_sensitive=True)(**kwargs)
-
-    async def async_exists(self):
-        __deprecation_warning()
-        return await sync_to_async(self.exists, thread_sensitive=True)()
-
-    async def async_count(self):
-        __deprecation_warning()
-        return await sync_to_async(self.count, thread_sensitive=True)()
-
-    async def async_explain(self, *_, format=None, **options):
-        __deprecation_warning()
-        return await sync_to_async(self.explain, thread_sensitive=True)(
-            *_, format=format, **options
-        )
-
-    async def async_raw(self, raw_query, params=None, translations=None, using=None):
-        __deprecation_warning()
-        return await sync_to_async(self.raw, thread_sensitive=True)(
-            raw_query, params=params, translations=translations, using=using
-        )
-
-    def __aiter__(self):
-        self._fetch_all()
-        return AsyncIter(self._result_cache)
-
-    def _fetch_all(self):
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future_fetch_all = executor.submit(super(QuerySetAsync, self)._fetch_all)
-
-    ##################################################################
-    # PUBLIC METHODS THAT ALTER ATTRIBUTES AND RETURN A NEW QUERYSET #
-    ##################################################################
-
-    async def async_all(self):
-        __deprecation_warning()
-        return await sync_to_async(self.all, thread_sensitive=True)()
-
-    async def async_filter(self, *args, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.filter, thread_sensitive=True)(*args, **kwargs)
-
-    async def async_exclude(self, *args, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.exclude, thread_sensitive=True)(*args, **kwargs)
-
-    async def async_complex_filter(self, filter_obj):
-        __deprecation_warning()
-        return await sync_to_async(self.complex_filter, thread_sensitive=True)(
-            filter_obj
-        )
-
-    async def async_union(self, *other_qs, all=False):
-        __deprecation_warning()
-        return await sync_to_async(self.union, thread_sensitive=True)(
-            *other_qs, all=all
-        )
-
-    async def async_intersection(self, *other_qs):
-        __deprecation_warning()
-        return await sync_to_async(self.intersection, thread_sensitive=True)(*other_qs)
-
-    async def async_difference(self, *other_qs):
-        __deprecation_warning()
-        return await sync_to_async(self.difference, thread_sensitive=True)(*other_qs)
-
-    async def async_select_for_update(self, nowait=False, skip_locked=False, of=()):
-        __deprecation_warning()
-        return await sync_to_async(self.select_for_update, thread_sensitive=True)(
-            nowait=nowait, skip_locked=skip_locked, of=of
-        )
-
-    async def async_prefetch_related(self, *lookups):
-        __deprecation_warning()
-        return await sync_to_async(self.prefetch_related, thread_sensitive=True)(
-            *lookups
-        )
-
-    async def async_annotate(self, *args, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.annotate, thread_sensitive=True)(
-            *args, **kwargs
-        )
-
-    async def async_order_by(self, *field_names):
-        __deprecation_warning()
-        return await sync_to_async(self.order_by, thread_sensitive=True)(*field_names)
-
-    async def async_distinct(self, *field_names):
-        __deprecation_warning()
-        return await sync_to_async(self.distinct, thread_sensitive=True)(*field_names)
-
-    async def async_extra(
-        self,
-        select=None,
-        where=None,
-        params=None,
-        tables=None,
-        order_by=None,
-        select_params=None,
-    ):
-        __deprecation_warning()
-        return await sync_to_async(self.extra, thread_sensitive=True)(
-            select, where, params, tables, order_by, select_params
-        )
-
-    async def async_reverse(self):
-        __deprecation_warning()
-        return await sync_to_async(self.reverse, thread_sensitive=True)()
-
-    async def async_defer(self, *fields):
-        __deprecation_warning()
-        return await sync_to_async(self.defer, thread_sensitive=True)(*fields)
-
-    async def async_only(self, *fields):
-        __deprecation_warning()
-        return await sync_to_async(self.only, thread_sensitive=True)(*fields)
-
-    async def async_using(self, alias):
-        __deprecation_warning()
-        return await sync_to_async(self.using, thread_sensitive=True)(alias)
-
-    async def async_resolve_expression(self, *args, **kwargs):
-        __deprecation_warning()
-        return await sync_to_async(self.resolve_expression, thread_sensitive=True)(
-            *args, **kwargs
-        )
-
-    @property
-    async def async_ordered(self):
-        __deprecation_warning()
-
-        def _ordered():
-            return super(QuerySetAsync, self).ordered
-
-        return await sync_to_async(_ordered, thread_sensitive=True)()
-
-
-class QuerySetAsync(__LegacyQuerySetAsync):
+class QuerySetAsync(QuerySet):
     def __init__(self, model=None, query=None, using=None, hints=None):
         super().__init__(model, query, using, hints)
 
@@ -393,3 +182,200 @@ class QuerySetAsync(__LegacyQuerySetAsync):
             return super(QuerySetAsync, self).ordered
 
         return await sync_to_async(_ordered, thread_sensitive=True)()
+
+    #################################
+    ### START OF DEPRECATION ZONE ###
+    #################################
+
+    async def async_get(self, *args, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.get, thread_sensitive=1)(*args, **kwargs)
+
+    async def async_create(self, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.create, thread_sensitive=True)(**kwargs)
+
+    async def async_bulk_create(self, obs, batch_size=None, ignore_conflicts=False):
+        __deprecation_warning()
+        return await sync_to_async(self.bulk_create, thread_sensitive=True)(
+            obs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
+        )
+
+    async def async_bulk_update(self, objs, fields, batch_size=None):
+        __deprecation_warning()
+        return await sync_to_async(self.bulk_update, thread_sensitive=True)(
+            objs=objs, fields=fields, batch_size=batch_size
+        )
+
+    async def async_get_or_create(self, defaults=None, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.get_or_create, thread_sensitive=True)(
+            defaults=defaults, **kwargs
+        )
+
+    async def async_update_or_create(self, defaults=None, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.update_or_create, thread_sensitive=True)(
+            defaults=defaults, **kwargs
+        )
+
+    async def async_earliest(self, *fields):
+        __deprecation_warning()
+        return await sync_to_async(self.earliest, thread_sensitive=True)(*fields)
+
+    async def async_latest(self, *fields):
+        __deprecation_warning()
+        return await sync_to_async(self.latest, thread_sensitive=True)(*fields)
+
+    async def async_first(self):
+        __deprecation_warning()
+        return await sync_to_async(self.first, thread_sensitive=True)()
+
+    async def async_none(self):
+        __deprecation_warning()
+        return await sync_to_async(self.none, thread_sensitive=True)()
+
+    async def async_last(self):
+        __deprecation_warning()
+        return await sync_to_async(self.last, thread_sensitive=True)()
+
+    async def async_in_bulk(self, id_list=None, *_, field_name="pk"):
+        __deprecation_warning()
+        return await sync_to_async(self.in_bulk, thread_sensitive=True)(
+            id_list=id_list, *_, field_name=field_name
+        )
+
+    async def async_delete(self):
+        __deprecation_warning()
+        return await sync_to_async(self.delete, thread_sensitive=True)()
+
+    async def async_update(self, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.update, thread_sensitive=True)(**kwargs)
+
+    async def async_exists(self):
+        __deprecation_warning()
+        return await sync_to_async(self.exists, thread_sensitive=True)()
+
+    async def async_count(self):
+        __deprecation_warning()
+        return await sync_to_async(self.count, thread_sensitive=True)()
+
+    async def async_explain(self, *_, format=None, **options):
+        __deprecation_warning()
+        return await sync_to_async(self.explain, thread_sensitive=True)(
+            *_, format=format, **options
+        )
+
+    async def async_raw(self, raw_query, params=None, translations=None, using=None):
+        __deprecation_warning()
+        return await sync_to_async(self.raw, thread_sensitive=True)(
+            raw_query, params=params, translations=translations, using=using
+        )
+
+    async def async_all(self):
+        __deprecation_warning()
+        return await sync_to_async(self.all, thread_sensitive=True)()
+
+    async def async_filter(self, *args, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.filter, thread_sensitive=True)(*args, **kwargs)
+
+    async def async_exclude(self, *args, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.exclude, thread_sensitive=True)(*args, **kwargs)
+
+    async def async_complex_filter(self, filter_obj):
+        __deprecation_warning()
+        return await sync_to_async(self.complex_filter, thread_sensitive=True)(
+            filter_obj
+        )
+
+    async def async_union(self, *other_qs, all=False):
+        __deprecation_warning()
+        return await sync_to_async(self.union, thread_sensitive=True)(
+            *other_qs, all=all
+        )
+
+    async def async_intersection(self, *other_qs):
+        __deprecation_warning()
+        return await sync_to_async(self.intersection, thread_sensitive=True)(*other_qs)
+
+    async def async_difference(self, *other_qs):
+        __deprecation_warning()
+        return await sync_to_async(self.difference, thread_sensitive=True)(*other_qs)
+
+    async def async_select_for_update(self, nowait=False, skip_locked=False, of=()):
+        __deprecation_warning()
+        return await sync_to_async(self.select_for_update, thread_sensitive=True)(
+            nowait=nowait, skip_locked=skip_locked, of=of
+        )
+
+    async def async_prefetch_related(self, *lookups):
+        __deprecation_warning()
+        return await sync_to_async(self.prefetch_related, thread_sensitive=True)(
+            *lookups
+        )
+
+    async def async_annotate(self, *args, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.annotate, thread_sensitive=True)(
+            *args, **kwargs
+        )
+
+    async def async_order_by(self, *field_names):
+        __deprecation_warning()
+        return await sync_to_async(self.order_by, thread_sensitive=True)(*field_names)
+
+    async def async_distinct(self, *field_names):
+        __deprecation_warning()
+        return await sync_to_async(self.distinct, thread_sensitive=True)(*field_names)
+
+    async def async_extra(
+        self,
+        select=None,
+        where=None,
+        params=None,
+        tables=None,
+        order_by=None,
+        select_params=None,
+    ):
+        __deprecation_warning()
+        return await sync_to_async(self.extra, thread_sensitive=True)(
+            select, where, params, tables, order_by, select_params
+        )
+
+    async def async_reverse(self):
+        __deprecation_warning()
+        return await sync_to_async(self.reverse, thread_sensitive=True)()
+
+    async def async_defer(self, *fields):
+        __deprecation_warning()
+        return await sync_to_async(self.defer, thread_sensitive=True)(*fields)
+
+    async def async_only(self, *fields):
+        __deprecation_warning()
+        return await sync_to_async(self.only, thread_sensitive=True)(*fields)
+
+    async def async_using(self, alias):
+        __deprecation_warning()
+        return await sync_to_async(self.using, thread_sensitive=True)(alias)
+
+    async def async_resolve_expression(self, *args, **kwargs):
+        __deprecation_warning()
+        return await sync_to_async(self.resolve_expression, thread_sensitive=True)(
+            *args, **kwargs
+        )
+
+    @property
+    async def async_ordered(self):
+        __deprecation_warning()
+
+        def _ordered():
+            return super(QuerySetAsync, self).ordered
+
+        return await sync_to_async(_ordered, thread_sensitive=True)()
+
+    ###############################
+    ### END OF DEPRECATION ZONE ###
+    ###############################

--- a/django_async_orm/query.py
+++ b/django_async_orm/query.py
@@ -17,7 +17,7 @@ def __deprecation_warning():
 
 
 def _priortize_django(method):
-    """Decorator used to prioritize built-in QuerySet methods over custom ones.
+    """Decorator used to prioritize Django's QuerySet methods over our custom ones.
 
     This will help maintain performance when Django adds real async support."""
 

--- a/django_async_orm/utils.py
+++ b/django_async_orm/utils.py
@@ -13,12 +13,11 @@ def mixin_async_manager_factory(model):
 
     base_manager_cls = model.objects.__class__
     if not base_manager_cls.__name__.startswith("MixinAsync"):
-        mixin_async_manager = type(
+        return type(
             f"MixinAsync{base_manager_cls.__name__}",
             (AsyncManager, base_manager_cls),
-            dict(),
+            {},
         )
-        return mixin_async_manager
 
 
 def patch_manager(model):
@@ -29,7 +28,7 @@ def patch_manager(model):
     :return: None
     :rtype: None
     """
-    async_manager_cls = mixin_async_manager_factory(model)
-    if async_manager_cls:
-        model.objects = async_manager_cls()
+    amanager_cls = mixin_async_manager_factory(model)
+    if amanager_cls:
+        model.objects = amanager_cls()
         model.objects.model = model

--- a/django_async_orm/utils.py
+++ b/django_async_orm/utils.py
@@ -28,7 +28,7 @@ def patch_manager(model):
     :return: None
     :rtype: None
     """
-    amanager_cls = mixin_async_manager_factory(model)
-    if amanager_cls:
-        model.objects = amanager_cls()
+    async_manager_cls = mixin_async_manager_factory(model)
+    if async_manager_cls:
+        model.objects = async_manager_cls()
         model.objects.model = model

--- a/django_async_orm/wrappers.py
+++ b/django_async_orm/wrappers.py
@@ -1,32 +1,13 @@
 from channels.db import database_sync_to_async as sync_to_async
 from django.contrib.auth import login, logout
-
-
-def _sync_render(*args, **kwargs):
-    from django.shortcuts import render
-
-    return render(*args, **kwargs)
-
-
-arender = sync_to_async(_sync_render, thread_sensitive=True)
-
-
-def _sync_login(*args, **kwargs):
-    return login(*args, *kwargs)
-
-
-alogin = sync_to_async(_sync_login, thread_sensitive=True)
-
-
-def _sync_logout(request):
-    return logout(request)
-
-
-alogout = sync_to_async(_sync_logout, thread_sensitive=True)
+from django.shortcuts import render
 
 
 def _sync_form_is_valid(form_instance):
     return form_instance.is_valid()
 
 
+arender = sync_to_async(render, thread_sensitive=True)
+alogin = sync_to_async(login, thread_sensitive=True)
+alogout = sync_to_async(logout, thread_sensitive=True)
 aform_is_valid = sync_to_async(_sync_form_is_valid, thread_sensitive=True)

--- a/django_async_orm/wrappers.py
+++ b/django_async_orm/wrappers.py
@@ -8,25 +8,25 @@ def _sync_render(*args, **kwargs):
     return render(*args, **kwargs)
 
 
-async_render = sync_to_async(_sync_render, thread_sensitive=True)
+arender = sync_to_async(_sync_render, thread_sensitive=True)
 
 
 def _sync_login(*args, **kwargs):
     return login(*args, *kwargs)
 
 
-async_login = sync_to_async(_sync_login, thread_sensitive=True)
+alogin = sync_to_async(_sync_login, thread_sensitive=True)
 
 
 def _sync_logout(request):
     return logout(request)
 
 
-async_logout = sync_to_async(_sync_logout, thread_sensitive=True)
+alogout = sync_to_async(_sync_logout, thread_sensitive=True)
 
 
 def _sync_form_is_valid(form_instance):
     return form_instance.is_valid()
 
 
-async_form_is_valid = sync_to_async(_sync_form_is_valid, thread_sensitive=True)
+aform_is_valid = sync_to_async(_sync_form_is_valid, thread_sensitive=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Topic :: Software Development :: Documentation",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
@@ -25,7 +24,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 channels = "^2.1.2"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+channels = "^2.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,7 @@ black==22.12.0; python_version >= "3.7"
 certifi==2022.12.7; python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 charset-normalizer==3.0.1; python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 click==8.1.3; python_version >= "3.7"
-codecov==2.1.12; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+codecov==2.1.13; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 colorama==0.4.6; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" and platform_system == "Windows" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.7.0" and platform_system == "Windows"
 coverage==7.1.0; python_version >= "3.7"
 distlib==0.3.6; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,7 +9,6 @@ codecov==2.1.13; (python_version >= "2.7" and python_full_version < "3.0.0") or 
 colorama==0.4.6; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" and platform_system == "Windows" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.7.0" and platform_system == "Windows"
 coverage==7.1.0; python_version >= "3.7"
 distlib==0.3.6; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-django==3.2.16; python_version >= "3.6"
 filelock==3.9.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 flake8==5.0.4; python_full_version >= "3.6.1"
 idna==3.4; python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -39,4 +39,4 @@ urllib3==1.26.14; python_version >= "3.7" and python_full_version < "3.0.0" and 
 virtualenv==20.16.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 wcwidth==0.2.6; python_version >= "3.5"
 zipp==3.11.0; python_version < "3.8" and python_version >= "3.7" and python_full_version >= "3.6.1" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6")
-channels
+channels>=2.1.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,41 +1,8 @@
-asgiref==3.6.0; python_version >= "3.7"
-atomicwrites==1.4.1; python_version >= "3.5" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.5" and python_full_version >= "3.4.0"
-attrs==22.2.0; python_version >= "3.6"
-black==22.12.0; python_version >= "3.7"
-certifi==2022.12.7; python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
-charset-normalizer==3.0.1; python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
-click==8.1.3; python_version >= "3.7"
-codecov==2.1.13; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-colorama==0.4.6; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" and platform_system == "Windows" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.7.0" and platform_system == "Windows"
-coverage==7.1.0; python_version >= "3.7"
-distlib==0.3.6; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-filelock==3.9.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
-flake8==5.0.4; python_full_version >= "3.6.1"
-idna==3.4; python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
-importlib-metadata==4.2.0; python_version < "3.8" and python_version >= "3.7" and python_full_version >= "3.6.1" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6")
-isort==5.11.4; python_full_version >= "3.7.0"
-mccabe==0.7.0; python_version >= "3.6" and python_full_version >= "3.6.1"
-more-itertools==9.0.0; python_version >= "3.7"
-mypy-extensions==0.4.3; python_version >= "3.7"
-packaging==23.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
-pathspec==0.11.0; python_version >= "3.7"
-platformdirs==2.6.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
-pluggy==0.13.1; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
-py==1.11.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
-pycodestyle==2.9.1; python_version >= "3.6" and python_full_version >= "3.6.1"
-pyflakes==2.5.0; python_version >= "3.6" and python_full_version >= "3.6.1"
-pytest==5.4.3; python_version >= "3.5"
-pytz==2022.7.1; python_version >= "3.6"
-requests==2.28.2; python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
-six==1.16.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
-sqlparse==0.4.3; python_version >= "3.6"
-tomli==2.0.1; python_full_version < "3.11.0a7" and python_version >= "3.7" and python_version < "3.11" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0")
-tox-pyenv==1.1.0
-tox==3.28.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-typed-ast==1.5.4; python_version < "3.8" and implementation_name == "cpython" and python_version >= "3.7"
-typing-extensions==4.4.0; python_version < "3.8" and python_version >= "3.7" and python_full_version >= "3.6.1" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6")
-urllib3==1.26.14; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0") or python_version >= "3.7" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0") and python_full_version >= "3.6.0"
-virtualenv==20.16.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-wcwidth==0.2.6; python_version >= "3.5"
-zipp==3.11.0; python_version < "3.8" and python_version >= "3.7" and python_full_version >= "3.6.1" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6")
+black
+codecov
+coverage
+flake8
+isort
+pytest
+tox
 channels>=2.1.2

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -46,3 +46,5 @@ LOGGING = {
         "level": "WARNING",
     },
 }
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/tests/test_django_async_orm.py
+++ b/tests/test_django_async_orm.py
@@ -127,9 +127,7 @@ class ModelTestCase(TransactionTestCase, IsolatedAsyncioTestCase):
 
     @tag("ci")
     async def test_async_explain(self):
-        explained = await (
-            await TestModel.objects.afilter(name="setup 1")
-        ).aexplain()
+        explained = await (await TestModel.objects.afilter(name="setup 1")).aexplain()
         print(explained)
         self.assertEqual(explained, "2 0 0 SCAN tests_testmodel")
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from django.conf.urls import url
 
 urlpatterns = []

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = True
 envlist =
     {py3}-django-3
-    {py38, py39, py310}-django-4
+    {py3}-django-4
 
 [tox.package]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 isolated_build = True
 envlist =
     {py3}-django-32
+    {py3}-django-4
 
 [tox.package]
 basepython = python3
@@ -11,5 +12,6 @@ setenv =
 commands = coverage run --source django_async_orm manage.py test -v2 {posargs}
 deps =
     django-32: Django>=3.2,<4.0
+    django-4: Django>=4.0,<5.0
     -r{toxinidir}/tests/requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 isolated_build = True
 envlist =
-    {py3}-django-32
-    {py3}-django-4
+    {py3}-django-3
+    {py38, py39, py310}-django-4
 
 [tox.package]
 basepython = python3
@@ -11,7 +11,7 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/django_async_orm
 commands = coverage run --source django_async_orm manage.py test -v2 {posargs}
 deps =
-    django-32: Django>=3.2,<4.0
+    django-3: Django>=3.2,<4.0
     django-4: Django>=4.0,<5.0
     -r{toxinidir}/tests/requirements.txt
 


### PR DESCRIPTION
## Changelog

- fix #21
   - Try to use Django's own `a*` functions (if they exist)
   - Create `a*` query functions
- Add deprecation warning to `async_*` query functions
- Fix dependency hell
- Test Django 4+
   - Add DEFAULT_AUTO_FIELD to test app
   - Bump minimum Python version to 3.8 (was easier then creating a new GitHub CI for testing to avoid Py3.7+Dj4)